### PR TITLE
add dependency setup

### DIFF
--- a/src/boot_fake_node/mod.rs
+++ b/src/boot_fake_node/mod.rs
@@ -1,4 +1,3 @@
-use std::io::Read;
 use std::{fs, io, thread, time};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -168,13 +168,9 @@ async fn compile_rust_wasm_process(
 
     let wasm_file_prefix = Path::new("target/wasm32-wasi/release");
     let wasm_file = wasm_file_prefix
-        .clone()
         .join(&format!("{}.wasm", wasm_file_name));
-        // .join(&format!("{}.wasm", process_dir.file_name().unwrap().to_str().unwrap()));
     let adapted_wasm_file = wasm_file_prefix
-        .clone()
         .join(&format!("{}_adapted.wasm", wasm_file_name));
-        // .join(&format!("{}_adapted.wasm", process_dir.file_name().unwrap().to_str().unwrap()));
 
     let wasi_snapshot_file = Path::new("wasi_snapshot_preview1.wasm");
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,10 +1,13 @@
 use std::fs::{self, File};
-use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
 use reqwest;
 use serde::{Serialize, Deserialize};
+
+use super::setup::{get_python_version, REQUIRED_PY_PACKAGE};
+
+const PY_VENV_NAME: &str = "process_env";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CargoFile {
@@ -23,12 +26,17 @@ struct Metadata {
     version: [u32; 3],
 }
 
-pub fn run_command(cmd: &mut Command) -> io::Result<()> {
+pub fn run_command(cmd: &mut Command) -> anyhow::Result<()> {
     let status = cmd.status()?;
     if status.success() {
         Ok(())
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "Command failed"))
+        Err(anyhow::anyhow!(
+            "Command `{} {:?}` failed with exit code {}",
+            cmd.get_program().to_str().unwrap(),
+            cmd.get_args().map(|a| a.to_str().unwrap()).collect::<Vec<_>>(),
+            status.code().unwrap(),
+        ))
     }
 }
 
@@ -61,12 +69,18 @@ async fn compile_python_wasm_process(
         .and_then(|s| s.to_str())
         .unwrap();
 
-    run_command(Command::new("componentize-py")
+    let python = get_python_version(None, None)?
+        .ok_or(anyhow::anyhow!("uqdev requires Python 3.10 or newer"))?;
+    run_command(Command::new(python)
+        .args(&["-m", "venv", PY_VENV_NAME])
+        .current_dir(process_dir)
+        .stdout(if verbose { Stdio::inherit() } else { Stdio::null() })
+        .stderr(if verbose { Stdio::inherit() } else { Stdio::null() })
+    )?;
+    run_command(Command::new("bash")
         .args(&[
-            "-d", "../wit/",
-            "-w", "process",
-            "componentize", "lib",
-            "-o", &format!("../../pkg/{wasm_file_name}.wasm")
+            "-c",
+            &format!("source ../{PY_VENV_NAME}/bin/activate && pip install {REQUIRED_PY_PACKAGE} && componentize-py -d ../wit/ -w process componentize lib -o ../../pkg/{wasm_file_name}.wasm"),
         ])
         .current_dir(process_dir.join("src"))
         .stdout(if verbose { Stdio::inherit() } else { Stdio::null() })

--- a/src/inject_message/mod.rs
+++ b/src/inject_message/mod.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::io::{self, Read};
 
+#[allow(deprecated)]
 use base64::encode;
 use reqwest;
 use serde_json::{Value, json};
@@ -36,6 +37,7 @@ pub fn make_message(
     raw_bytes: Option<&[u8]>,
     bytes_path: Option<&str>,
 ) -> io::Result<Value> {
+    #[allow(deprecated)]
     let data = match (raw_bytes, bytes_path) {
         (Some(bytes), None) => Some(encode(bytes)),
         (None, Some(path)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod inject_message;
 mod new;
 mod remove_package;
 mod run_tests;
+mod setup;
 mod start_package;
 
 async fn execute(
@@ -110,6 +111,7 @@ async fn execute(
             let is_delete = !remove_package_matches.get_one::<bool>("UNINSTALL_ONLY").unwrap();
             remove_package::execute(package_dir, url, node, package_name, publisher, is_delete).await
         },
+        Some(("setup", _setup_matches)) => setup::execute(),
         Some(("start-package", start_package_matches)) => {
             let package_dir = PathBuf::from(start_package_matches.get_one::<String>("DIR").unwrap());
             let url: &String = start_package_matches.get_one("URL").unwrap();
@@ -342,6 +344,9 @@ async fn main() -> anyhow::Result<()> {
                 .help("Only uninstall the package; don't delete it from node")
                 .long("uninstall-only")
             )
+        )
+        .subcommand(Command::new("setup")
+            .about("Fetch & setup Uqdev dependencies")
         )
         .subcommand(Command::new("start-package")
             .about("Start a built Uqbar process")

--- a/src/new/templates/python/no-ui/chat/.gitignore
+++ b/src/new/templates/python/no-ui/chat/.gitignore
@@ -4,3 +4,4 @@ pkg/*.wasm
 *.swo
 */wasi_snapshot_preview1.wasm
 */wit/
+*/process_env

--- a/src/new/templates/rust/no-ui/chat/.gitignore
+++ b/src/new/templates/rust/no-ui/chat/.gitignore
@@ -4,3 +4,4 @@ pkg/*.wasm
 *.swo
 */wasi_snapshot_preview1.wasm
 */wit/
+*/process_env

--- a/src/new/templates/rust/ui/chat/.gitignore
+++ b/src/new/templates/rust/ui/chat/.gitignore
@@ -4,3 +4,4 @@ pkg/*.wasm
 *.swo
 */wasi_snapshot_preview1.wasm
 */wit/
+*/process_env

--- a/src/remove_package/mod.rs
+++ b/src/remove_package/mod.rs
@@ -1,12 +1,9 @@
 use std::fs;
 use std::io;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 
 use serde_json::json;
-use walkdir::WalkDir;
-use zip::write::FileOptions;
 
 use super::inject_message;
 

--- a/src/run_tests/network_router.rs
+++ b/src/run_tests/network_router.rs
@@ -70,7 +70,7 @@ async fn handle_connection(
 
 pub async fn execute(
     port: u16,
-    defects: NetworkRouterDefects,
+    _defects: NetworkRouterDefects,
     mut recv_kill_in_router: BroadcastRecvBool,
 ) -> anyhow::Result<()> {
     let (send_to_loop, mut recv_in_loop): (Sender, Receiver) = mpsc::channel(32);

--- a/src/run_tests/tester_types.rs
+++ b/src/run_tests/tester_types.rs
@@ -1,8 +1,7 @@
 use serde::{Serialize, Deserialize};
 
-use uqbar_process_lib::{Address, Response};
+use uqbar_process_lib::Address;
 use uqbar_process_lib::kernel_types as kt;
-// use uqbar_process_lib::uqbar::process::standard as wit;
 
 type Rsvp = Option<Address>;
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,0 +1,209 @@
+use std::env;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::str;
+
+use super::build::run_command;
+
+const FETCH_NVM_VERSION: &str = "v0.39.7";
+const REQUIRED_NODE_MAJOR: u32 = 18;
+const MINIMUM_NODE_MINOR: u32 = 0;
+const REQUIRED_NPM_MAJOR: u32 = 9;
+const MINIMUM_NPM_MINOR: u32 = 0;
+pub const REQUIRED_PY_MAJOR: u32 = 3;
+pub const MINIMUM_PY_MINOR: u32 = 10;
+pub const REQUIRED_PY_PACKAGE: &str = "componentize-py==0.7.1";
+
+fn check_and_install_nvm() -> anyhow::Result<()> {
+    if !is_nvm_installed()? {
+        install_nvm()?;
+    } else {
+        println!("Found nvm.");
+    }
+    Ok(())
+}
+
+fn is_nvm_installed() -> anyhow::Result<bool> {
+    let home_dir = env::var("HOME")?;
+    let nvm_dir = format!("{}/.nvm", home_dir);
+    Ok(std::path::Path::new(&nvm_dir).exists())
+}
+
+fn install_nvm() -> anyhow::Result<()> {
+    println!("Getting nvm...");
+    let install_script = format!(
+        "https://raw.githubusercontent.com/nvm-sh/nvm/{FETCH_NVM_VERSION}/install.sh"
+    );
+    run_command(Command::new("bash")
+        .args(&["-c", &format!("curl -o- {install_script} | bash")])
+        .stdout(Stdio::null())
+    )?;
+
+    println!("Done getting nvm.");
+    Ok(())
+}
+
+fn check_and_install_node() -> anyhow::Result<()> {
+    if !is_command_installed("node")? || !is_version_correct("node", (REQUIRED_NODE_MAJOR, MINIMUM_NODE_MINOR))? {
+        let node_version = format!("{}.{}", REQUIRED_NODE_MAJOR, MINIMUM_NODE_MINOR);
+        println!("Installing or updating Node.js to version {}...", node_version);
+        call_nvm(&format!("install {}", node_version))?;
+        println!("Done installing or updating Node.js to version {}.", node_version);
+    } else {
+        println!("Found node.");
+    }
+    Ok(())
+}
+
+fn check_and_install_npm() -> anyhow::Result<()> {
+    if !is_command_installed("npm")? || !is_version_correct("npm", (REQUIRED_NPM_MAJOR, MINIMUM_NODE_MINOR))? {
+        let npm_version = format!("{}.{}", REQUIRED_NPM_MAJOR, MINIMUM_NPM_MINOR);
+        println!("Installing or updating npm to version {}...", npm_version);
+        call_nvm(&format!("install-latest-npm"))?;
+        println!("Done installing or updating npm to version {}...", npm_version);
+    } else {
+        println!("Found npm.");
+    }
+    Ok(())
+}
+
+fn check_python_venv(python: &str) -> anyhow::Result<()> {
+    println!("Testing python venv capability...");
+    let venv_result = run_command(Command::new(python)
+        .args(&["-m", "venv", "uqbar-test-venv"])
+        .current_dir("/tmp")
+    );
+    let venv_dir = PathBuf::from("/tmp/uqbar-test-venv");
+    if venv_dir.exists() {
+        std::fs::remove_dir_all(&venv_dir)?;
+    }
+    match venv_result {
+        Ok(_) => {
+            println!("Done testing python venv capability.");
+            Ok(())
+        },
+        Err(_) => Err(anyhow::anyhow!("Done testing python venv capability: could not create python venv.")),
+    }
+}
+
+fn is_command_installed(cmd: &str) -> anyhow::Result<bool> {
+    Ok(Command::new("which")
+        .arg(cmd)
+        .stdout(Stdio::null())
+        .status()?
+        .success()
+    )
+}
+
+fn is_version_correct(cmd: &str, required_version: (u32, u32)) -> anyhow::Result<bool> {
+    let output = Command::new(cmd)
+        .arg("--version")
+        .output()?
+        .stdout;
+
+    let version = String::from_utf8_lossy(&output);
+
+    Ok(parse_version(version.trim())
+        .and_then(|v| Some(compare_versions(v, required_version)))
+        .unwrap_or(false)
+    )
+}
+
+fn call_nvm(arg: &str) -> anyhow::Result<()> {
+    run_command(Command::new("bash")
+        .arg("-c")
+        .arg(format!("source ~/.nvm/nvm.sh && nvm {}", arg))
+    )?;
+    Ok(())
+}
+
+fn compare_versions(installed_version: (u32, u32) , required_version: (u32, u32)) -> bool {
+    installed_version.0 == required_version.0 && installed_version.1 >= required_version.1
+}
+
+fn parse_version(version_str: &str) -> Option<(u32, u32)> {
+    let mut parts: Vec<&str> = version_str.split('.').collect();
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Remove leading 'v' from the first part if present
+    parts[0] = parts[0].trim_start_matches('v');
+
+    if parts.len() >= 2 {
+        if let (Ok(major), Ok(minor)) = (parts[0].parse(), parts[1].parse()) {
+            return Some((major, minor));
+        }
+    }
+
+    None
+}
+
+/// Find the newest Python version (>= 3.10 or given major, minor)
+pub fn get_python_version(
+    required_major: Option<u32>,
+    minimum_minor: Option<u32>,
+) -> anyhow::Result<Option<String>> {
+    let required_major = required_major.unwrap_or(REQUIRED_PY_MAJOR);
+    let minimum_minor = minimum_minor.unwrap_or(MINIMUM_PY_MINOR);
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg("for dir in $(echo $PATH | tr ':' ' '); do for cmd in $(echo $dir/python3*); do which $(basename $cmd) 2>/dev/null; done; done")
+        .output()?;
+
+    let commands = str::from_utf8(&output.stdout)?;
+    let python_versions = commands.split_whitespace();
+
+    let mut newest_python = None;
+    let mut max_version = (0, 0); // (major, minor)
+
+    for python in python_versions {
+        let version_output = Command::new(python)
+            .arg("--version")
+            .output()?;
+
+        let version_str = str::from_utf8(&version_output.stdout).unwrap_or("");
+        if version_str.is_empty() {
+            continue;
+        }
+
+        if let Some(version) = version_str.split_whitespace().nth(1) {
+            if let Some((major, minor)) = parse_version(version) {
+                if major == required_major && minor >= minimum_minor && (major, minor) > max_version {
+                    max_version = (major, minor);
+                    newest_python = Some(python.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(newest_python)
+}
+
+pub fn execute() -> anyhow::Result<()> {
+    let python = get_python_version(Some(REQUIRED_PY_MAJOR), Some(MINIMUM_PY_MINOR))?
+        .ok_or(anyhow::anyhow!("uqdev requires Python 3.10 or newer"))?;
+    // If setup required, request user permission
+    print!("Do you want to fetch Uqdev dependencies (nvm, npm, node, componentize-py)?\nWill install automatically if yes: [y/N]: ");
+    // Flush to ensure the prompt is displayed before input
+    io::stdout().flush().unwrap();
+
+    // Read the user's response
+    let mut response = String::new();
+    io::stdin().read_line(&mut response).unwrap();
+
+    // Process the response
+    let response = response.trim().to_lowercase(); // Normalize the input
+    match response.as_str() {
+        "y" | "yes" | "" => {
+            check_and_install_nvm()?;
+            check_and_install_node()?;
+            check_and_install_npm()?;
+            check_python_venv(&python)?;
+        },
+        _ => println!("Function execution cancelled."), // Do not execute otherwise
+    }
+    Ok(())
+}

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -183,10 +183,11 @@ pub fn get_python_version(
 }
 
 pub fn execute() -> anyhow::Result<()> {
+    println!("Setting up...");
     let python = get_python_version(Some(REQUIRED_PY_MAJOR), Some(MINIMUM_PY_MINOR))?
         .ok_or(anyhow::anyhow!("uqdev requires Python 3.10 or newer"))?;
     // If setup required, request user permission
-    print!("Do you want to fetch Uqdev dependencies (nvm, npm, node, componentize-py)?\nWill install automatically if yes: [y/N]: ");
+    print!("Do you want to check Uqdev dependencies and install any that are not found (nvm, npm, node, componentize-py)? [Y/n]: ");
     // Flush to ensure the prompt is displayed before input
     io::stdout().flush().unwrap();
 
@@ -202,8 +203,9 @@ pub fn execute() -> anyhow::Result<()> {
             check_and_install_node()?;
             check_and_install_npm()?;
             check_python_venv(&python)?;
+            println!("Done setting up.");
         },
-        _ => println!("Function execution cancelled."), // Do not execute otherwise
+        _ => println!("Skipped setting up."),
     }
     Ok(())
 }


### PR DESCRIPTION
Add `uqdev setup`, which fetches deps if they are out of date -- or at worst notifies user that deps must be fetched.

Also updates `uqdev build` to build python processes using a `venv` version of `componentize-py` to avoid running into issues with user's current global py deps.

Still TODO:
~~[ ] run `setup` on `build.rs`~~
[x] run `setup` on first call